### PR TITLE
Fix a small issue with the example file having an additional env var left over from testing.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ LINUX_CERTIFICATE=                    # Base64-encoded GPG private key for signi
 # NPM Publishing
 # --------------
 NPM_TOKEN=                            # NPM authentication token for publishing packages
-PORT=3000 # node port
+
 # =============================================================================
 # HOW TO GENERATE CERTIFICATES
 # =============================================================================


### PR DESCRIPTION
Fix unused env var.