### PR TITLE
Publish under Loggipop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,9 +403,9 @@ jobs:
           # Linux packages
           if [ -f packages/lpop-linux-x64/lpop-linux-x64 ]; then
             if [ "${{ needs.check-certificates.outputs.has-linux-cert }}" == "true" ]; then
-              echo "Publishing lpop-linux-x64 (signed)..."
+              echo "Publishing @loggipop/lpop-linux-x64 (signed)..."
             else
-              echo "Publishing lpop-linux-x64 (unsigned)..."
+              echo "Publishing @loggipop/lpop-linux-x64 (unsigned)..."
             fi
             cd packages/lpop-linux-x64
             bun publish --access public
@@ -415,9 +415,9 @@ jobs:
           
           if [ -f packages/lpop-linux-arm64/lpop-linux-arm64 ]; then
             if [ "${{ needs.check-certificates.outputs.has-linux-cert }}" == "true" ]; then
-              echo "Publishing lpop-linux-arm64 (signed)..."
+              echo "Publishing @loggipop/lpop-linux-arm64 (signed)..."
             else
-              echo "Publishing lpop-linux-arm64 (unsigned)..."
+              echo "Publishing @loggipop/lpop-linux-arm64 (unsigned)..."
             fi
             cd packages/lpop-linux-arm64
             bun publish --access public
@@ -428,7 +428,7 @@ jobs:
           # macOS packages (only signed)
           if [ "${{ needs.check-certificates.outputs.has-macos-cert }}" == "true" ]; then
             if [ -f packages/lpop-darwin-x64/lpop-darwin-x64 ]; then
-              echo "Publishing lpop-darwin-x64 (signed)..."
+              echo "Publishing @loggipop/lpop-darwin-x64 (signed)..."
               cd packages/lpop-darwin-x64
               bun publish --access public
               cd ../..
@@ -436,7 +436,7 @@ jobs:
             fi
             
             if [ -f packages/lpop-darwin-arm64/lpop-darwin-arm64 ]; then
-              echo "Publishing lpop-darwin-arm64 (signed)..."
+              echo "Publishing @loggipop/lpop-darwin-arm64 (signed)..."
               cd packages/lpop-darwin-arm64
               bun publish --access public
               cd ../..
@@ -447,9 +447,9 @@ jobs:
           # Windows packages
           if [ -f packages/lpop-windows-x64/lpop-windows-x64.exe ]; then
             if [ "${{ needs.check-certificates.outputs.has-windows-cert }}" == "true" ]; then
-              echo "Publishing lpop-windows-x64 (signed)..."
+              echo "Publishing @loggipop/lpop-windows-x64 (signed)..."
             else
-              echo "Publishing lpop-windows-x64 (unsigned)..."
+              echo "Publishing @loggipop/lpop-windows-x64 (unsigned)..."
             fi
             cd packages/lpop-windows-x64
             bun publish --access public
@@ -471,25 +471,25 @@ jobs:
 
           // Include Linux packages if binaries exist (signed or unsigned)
           if (fs.existsSync('packages/lpop-linux-x64/lpop-linux-x64')) {
-            optDeps['lpop-linux-x64'] = pkg.version;
+            optDeps['@loggipop/lpop-linux-x64'] = pkg.version;
           }
           if (fs.existsSync('packages/lpop-linux-arm64/lpop-linux-arm64')) {
-            optDeps['lpop-linux-arm64'] = pkg.version;
+            optDeps['@loggipop/lpop-linux-arm64'] = pkg.version;
           }
 
           // Include macOS packages only if signed (requirement remains)
           if ('${{ needs.check-certificates.outputs.has-macos-cert }}' === 'true') {
             if (fs.existsSync('packages/lpop-darwin-x64/lpop-darwin-x64')) {
-              optDeps['lpop-darwin-x64'] = pkg.version;
+              optDeps['@loggipop/lpop-darwin-x64'] = pkg.version;
             }
             if (fs.existsSync('packages/lpop-darwin-arm64/lpop-darwin-arm64')) {
-              optDeps['lpop-darwin-arm64'] = pkg.version;
+              optDeps['@loggipop/lpop-darwin-arm64'] = pkg.version;
             }
           }
 
           // Include Windows packages if binaries exist (signed or unsigned)
           if (fs.existsSync('packages/lpop-windows-x64/lpop-windows-x64.exe')) {
-            optDeps['lpop-windows-x64'] = pkg.version;
+            optDeps['@loggipop/lpop-windows-x64'] = pkg.version;
           }
 
           pkg.optionalDependencies = optDeps;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-lpop is a CLI tool for managing environment variables securely in the system keychain. It uses git repository context to organize variables by repo and environment.
+lpop (@loggipop/lpop) is a CLI tool for managing environment variables securely in the system keychain. It uses git repository context to organize variables by repo and environment.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ lpop stores your environment variables in the system keychain (macOS Keychain, W
 
 ```bash
 # Install globally with npm
-npm install -g lpop
+npm install -g @loggipop/lpop
 ```
 
 ## 📖 How It Works

--- a/bun.lock
+++ b/bun.lock
@@ -22,11 +22,11 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "lpop-darwin-arm64": "*",
-        "lpop-darwin-x64": "*",
-        "lpop-linux-arm64": "*",
-        "lpop-linux-x64": "*",
-        "lpop-windows-x64": "*",
+        "@loggipop/lpop-darwin-arm64": "*",
+        "@loggipop/lpop-darwin-x64": "*",
+        "@loggipop/lpop-linux-arm64": "*",
+        "@loggipop/lpop-linux-x64": "*",
+        "@loggipop/lpop-windows-x64": "*",
       },
     },
   },
@@ -348,16 +348,6 @@
     "lefthook-windows-x64": ["lefthook-windows-x64@1.12.3", "", { "os": "win32", "cpu": "x64" }, "sha512-7Co/L8e2x2hGC1L33jDJ4ZlTkO3PJm25GOGpLfN1kqwhGB/uzMLeTI/PBczjlIN8isUv26ouNd9rVR7Bibrwyg=="],
 
     "loupe": ["loupe@3.2.0", "", {}, "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw=="],
-
-    "lpop-darwin-arm64": ["lpop-darwin-arm64@0.1.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/5S/kps4Aq+vWTxPBKpUok+ToSr0w4SsUvi7WdWacGQZISLCIziFhWNJs/N8/y54/1KlOl7jnk7vAyC/oZBX8g=="],
-
-    "lpop-darwin-x64": ["lpop-darwin-x64@0.1.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-EOEow22WvtXRAm3nbJBvZV2ee+2OtcabNjYFb6gwWXL5kwwCNLOTqXUA+/XL155hsq3SqenJBZffKf8XYAjYEQ=="],
-
-    "lpop-linux-arm64": ["lpop-linux-arm64@0.1.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-9wyLRkbWFrcvNCKP7ym2t3VxDwA77gtbD5k30N8qt4FRfYX5CmMmFgBQ/mcCptkh0UdhK0AOX/q/ac3kH38NQw=="],
-
-    "lpop-linux-x64": ["lpop-linux-x64@0.1.13", "", { "os": "linux", "cpu": "x64" }, "sha512-MxGBWXWOZZL/7hFtI43CL0FegHobOa7SnUaSsxV8HOmLB1cSsQ0jfn7BCKdcF/jcmesqXk8W8v/61otiw34x4w=="],
-
-    "lpop-windows-x64": ["lpop-windows-x64@0.1.13", "", { "os": "win32", "cpu": "x64" }, "sha512-dGn5+TjKKHDdkO7Rc6Yt515lOuNYFqUUWk7HxeZfhGRKWQ4ars3syHdyLI9mPNNbIjiQRtqO5Mnqfpevz7e/EA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/deprecation-package/README.md
+++ b/deprecation-package/README.md
@@ -1,0 +1,31 @@
+# ⚠️ DEPRECATED: lpop has moved to @loggipop/lpop
+
+This package has been deprecated and moved to the `@loggipop` organization scope.
+
+## Migration Instructions
+
+1. **Uninstall the old package:**
+   ```bash
+   npm uninstall -g lpop
+   ```
+
+2. **Install the new scoped package:**
+   ```bash
+   npm install -g @loggipop/lpop
+   ```
+
+The `lpop` command will continue to work exactly the same with the new package.
+
+## Why the move?
+
+- **Security**: Scoped packages reduce the risk of typosquatting attacks
+- **Organization**: All packages are now properly organized under the `@loggipop` scope
+- **Professionalism**: Scoped packages provide better namespace management
+
+## Need Help?
+
+If you encounter any issues during migration, please visit:
+- [GitHub Issues](https://github.com/loggipop/lpop/issues)
+- [Documentation](https://github.com/loggipop/lpop#readme)
+
+Thank you for using lpop! 🙏

--- a/deprecation-package/deprecation-notice.js
+++ b/deprecation-package/deprecation-notice.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+console.log('\n⚠️  DEPRECATION NOTICE ⚠️');
+console.log('━'.repeat(50));
+console.log('The "lpop" package has moved to "@loggipop/lpop"');
+console.log('');
+console.log('To migrate:');
+console.log('  1. Uninstall the old package:');
+console.log('     npm uninstall -g lpop');
+console.log('');
+console.log('  2. Install the new scoped package:');
+console.log('     npm install -g @loggipop/lpop');
+console.log('');
+console.log('The command "lpop" will continue to work with the new package.');
+console.log('━'.repeat(50));
+console.log('');

--- a/deprecation-package/package.json
+++ b/deprecation-package/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "lpop",
+  "version": "0.2.1",
+  "description": "DEPRECATED - Package moved to @loggipop/lpop",
+  "type": "module",
+  "bin": {
+    "lpop": "./bin/lpop-deprecation"
+  },
+  "scripts": {
+    "postinstall": "node deprecation-notice.js"
+  },
+  "keywords": [
+    "cli",
+    "environment",
+    "variables",
+    "keychain",
+    "git",
+    "deprecated"
+  ],
+  "author": "Loggipop",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/loggipop/lpop.git"
+  },
+  "bugs": {
+    "url": "https://github.com/loggipop/lpop/issues"
+  },
+  "homepage": "https://github.com/loggipop/lpop#readme",
+  "files": [
+    "bin/lpop-deprecation",
+    "deprecation-notice.js",
+    "README.md"
+  ],
+  "deprecated": "Package moved to @loggipop/lpop. Please install @loggipop/lpop instead."
+}

--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-  "name": "lpop",
-  "version": "0.2.0",
-  "description": "A CLI tool for managing environment variables in the system keychain",
-  "type": "module",
-  "bin": {
-    "lpop": "./bin/lpop"
-  },
-  "scripts": {
-    "build:binaries": "./scripts/build-binary.sh",
-    "build:sign-notarize": "./scripts/build-sign-notarize.sh",
-    "prepare-packages": "node scripts/prepare-packages.js",
-    "dev": "bun run src/index.ts",
-    "clean": "rm -rf dist/ lpop lpop-*",
-    "lint": "biome check",
-    "lint:fix": "biome check --write",
-    "prepack": "bun run build:binaries && bun run prepare-packages",
-    "postinstall": "node scripts/postinstall.js",
-    "test": "vitest --run",
-    "test:watch": "vitest --watch",
-    "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
-  },
-  "keywords": [
-    "cli",
-    "environment",
-    "variables",
-    "keychain",
-    "git"
-  ],
-  "author": "Loggipop",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/loggipop/lpop.git"
-  },
-  "bugs": {
-    "url": "https://github.com/loggipop/lpop/issues"
-  },
-  "homepage": "https://github.com/loggipop/lpop#readme",
-  "devDependencies": {
-    "@biomejs/biome": "2.1.4",
-    "@napi-rs/keyring": "^1.1.8",
-    "@types/bun": "latest",
-    "@types/node": "^24.2.0",
-    "@vitest/coverage-v8": "^3.2.4",
-    "@vitest/ui": "^3.2.4",
-    "chalk": "^5.4.1",
-    "commander": "^14.0.0",
-    "dotenv": "^17.2.0",
-    "git-url-parse": "^16.1.0",
-    "happy-dom": "^18.0.1",
-    "lefthook": "^1.12.3",
-    "simple-git": "^3.28.0",
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
-    "vitest": "^3.2.4"
-  },
-  "optionalDependencies": {
-    "lpop-linux-x64": "*",
-    "lpop-linux-arm64": "*",
-    "lpop-darwin-x64": "*",
-    "lpop-darwin-arm64": "*",
-    "lpop-windows-x64": "*"
-  },
-  "files": [
-    "bin/lpop",
-    "scripts/postinstall.js",
-    "README.md",
-    "LICENSE"
-  ]
+	"name": "@loggipop/lpop",
+	"version": "0.3.0",
+	"description": "A CLI tool for managing environment variables in the system keychain",
+	"type": "module",
+	"bin": {
+		"lpop": "./bin/lpop"
+	},
+	"scripts": {
+		"build:binaries": "./scripts/build-binary.sh",
+		"build:sign-notarize": "./scripts/build-sign-notarize.sh",
+		"prepare-packages": "node scripts/prepare-packages.js",
+		"dev": "bun run src/index.ts",
+		"clean": "rm -rf dist/ lpop lpop-*",
+		"lint": "biome check",
+		"lint:fix": "biome check --write",
+		"prepack": "bun run build:binaries && bun run prepare-packages",
+		"postinstall": "node scripts/postinstall.js",
+		"test": "vitest --run",
+		"test:watch": "vitest --watch",
+		"test:ui": "vitest --ui",
+		"test:coverage": "vitest --coverage"
+	},
+	"keywords": [
+		"cli",
+		"environment",
+		"variables",
+		"keychain",
+		"git"
+	],
+	"author": "Loggipop",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/loggipop/lpop.git"
+	},
+	"bugs": {
+		"url": "https://github.com/loggipop/lpop/issues"
+	},
+	"homepage": "https://github.com/loggipop/lpop#readme",
+	"devDependencies": {
+		"@biomejs/biome": "2.1.4",
+		"@napi-rs/keyring": "^1.1.8",
+		"@types/bun": "latest",
+		"@types/node": "^24.2.0",
+		"@vitest/coverage-v8": "^3.2.4",
+		"@vitest/ui": "^3.2.4",
+		"chalk": "^5.4.1",
+		"commander": "^14.0.0",
+		"dotenv": "^17.2.0",
+		"git-url-parse": "^16.1.0",
+		"happy-dom": "^18.0.1",
+		"lefthook": "^1.12.3",
+		"simple-git": "^3.28.0",
+		"tsx": "^4.19.2",
+		"typescript": "^5.7.2",
+		"vitest": "^3.2.4"
+	},
+	"optionalDependencies": {
+		"@loggipop/lpop-linux-x64": "0.3.0",
+		"@loggipop/lpop-linux-arm64": "0.3.0",
+		"@loggipop/lpop-darwin-x64": "0.3.0",
+		"@loggipop/lpop-darwin-arm64": "0.3.0",
+		"@loggipop/lpop-windows-x64": "0.3.0"
+	},
+	"files": [
+		"bin/lpop",
+		"scripts/postinstall.js",
+		"README.md",
+		"LICENSE"
+	]
 }

--- a/packages/lpop-darwin-arm64/package.json
+++ b/packages/lpop-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lpop-darwin-arm64",
-  "version": "0.1.13",
+  "name": "@loggipop/lpop-darwin-arm64",
+  "version": "0.3.0",
   "description": "lpop binary for macOS arm64",
   "os": [
     "darwin"

--- a/packages/lpop-darwin-x64/package.json
+++ b/packages/lpop-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lpop-darwin-x64",
-  "version": "0.1.13",
+  "name": "@loggipop/lpop-darwin-x64",
+  "version": "0.3.0",
   "description": "lpop binary for macOS x64",
   "os": [
     "darwin"

--- a/packages/lpop-linux-arm64/package.json
+++ b/packages/lpop-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lpop-linux-arm64",
-  "version": "0.1.13",
+  "name": "@loggipop/lpop-linux-arm64",
+  "version": "0.3.0",
   "description": "lpop binary for Linux arm64",
   "os": [
     "linux"

--- a/packages/lpop-linux-x64/package.json
+++ b/packages/lpop-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lpop-linux-x64",
-  "version": "0.1.13",
+  "name": "@loggipop/lpop-linux-x64",
+  "version": "0.3.0",
   "description": "lpop binary for Linux x64",
   "os": [
     "linux"

--- a/packages/lpop-windows-x64/package.json
+++ b/packages/lpop-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lpop-windows-x64",
-  "version": "0.1.13",
+  "name": "@loggipop/lpop-windows-x64",
+  "version": "0.3.0",
   "description": "lpop binary for Windows x64",
   "os": [
     "win32"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -62,7 +62,6 @@ async function setupBinary() {
 
   const { platform, arch } = getPlatformInfo();
   const target = `${platform}-${arch}`;
-  const packageName = `lpop-${target}`;
   const binaryName =
     platform === 'windows' ? `lpop-${target}.exe` : `lpop-${target}`;
 
@@ -72,7 +71,8 @@ async function setupBinary() {
   const optionalDepPath = join(
     packageRoot,
     'node_modules',
-    packageName,
+    '@loggipop',
+    `lpop-${target}`,
     binaryName,
   );
   if (existsSync(optionalDepPath)) {

--- a/scripts/prepare-packages.js
+++ b/scripts/prepare-packages.js
@@ -25,11 +25,11 @@ console.log(`Main package version: ${mainVersion}`);
 
 for (const { name: platform, arch } of platforms) {
   const target = `${platform}-${arch}`;
-  const packageName = `lpop-${target}`;
+  const packageName = `@loggipop/lpop-${target}`;
   const packageJsonPath = join(
     packageRoot,
     'packages',
-    packageName,
+    `lpop-${target}`,
     'package.json',
   );
 
@@ -48,7 +48,7 @@ console.log(
 if (mainPackageJson.optionalDependencies) {
   let updated = false;
   for (const dep in mainPackageJson.optionalDependencies) {
-    if (dep.startsWith('lpop-')) {
+    if (dep.startsWith('@loggipop/lpop-')) {
       mainPackageJson.optionalDependencies[dep] = mainVersion;
       updated = true;
     }
@@ -66,12 +66,12 @@ console.log('📦 Copying binaries to platform packages...');
 
 for (const { name: platform, arch } of platforms) {
   const target = `${platform}-${arch}`;
-  const packageName = `lpop-${target}`;
+  const packageName = `@loggipop/lpop-${target}`;
   const binaryName =
     platform === 'windows' ? `lpop-${target}.exe` : `lpop-${target}`;
 
   const sourcePath = join(packageRoot, 'dist', binaryName);
-  const destDir = join(packageRoot, 'packages', packageName);
+  const destDir = join(packageRoot, 'packages', `lpop-${target}`);
   const destPath = join(destDir, binaryName);
 
   if (existsSync(sourcePath)) {


### PR DESCRIPTION
## Related Issue

Closes #40

## Summary of Changes

  ✅ Main package updated: Changed from lpop to @loggipop/lpop (v0.3.0)
  ✅ Platform packages updated: All binary packages now use scoped names (@loggipop/lpop-*)
  ✅ Build scripts updated: prepare-packages.js and postinstall.js now handle scoped packages
  ✅ Documentation updated: README.md and CLAUDE.md reflect new package name
  ✅ Deprecation package created: Complete package in deprecation-package/ for old lpop
  ✅ Local testing passed: Build, tests, and binary all work correctly

## Risk Assessment

- [ ] Low
- [X] Medium
- [ ] High
